### PR TITLE
fix: Reduce openfeature lower bound to 1.13 instead of 1.14

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -107,7 +107,7 @@ nexusPublishing {
 dependencies {
     implementation group: 'com.launchdarkly', name: 'launchdarkly-java-server-sdk', version: '[7.1.0, 8.0.0)'
 
-    implementation 'dev.openfeature:sdk:[1.14.0,2.0.0)'
+    implementation 'dev.openfeature:sdk:[1.13.0,2.0.0)'
 
     // Use JUnit test framework
     testImplementation(platform('org.junit:junit-bom:5.10.0'))


### PR DESCRIPTION
**Requirements**

- [x] I have added test coverage for new or changed functionality
- [x] I have followed the repository's [pull request submission guidelines](../blob/main/CONTRIBUTING.md#submitting-pull-requests)
- [x] I have validated my changes against all supported platform versions

Tracking was added in 1.13.0 so we can move the under bound from 1.14.0 (current minor version as of now) to 1.13.0


