### PR TITLE
chore: Remove id-token permission from publish-docs workflow

### DIFF
--- a/.github/workflows/publish-docs.yml
+++ b/.github/workflows/publish-docs.yml
@@ -6,7 +6,6 @@ jobs:
   build-and-publish:
     runs-on: ubuntu-latest
     permissions:
-      id-token: read # No OIDC needed.
       contents: write # For publishing documentation.
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Removes an unused GitHub Actions permission; behavior should be unchanged aside from reduced token scope.
> 
> **Overview**
> Tightens the `publish-docs` GitHub Actions workflow by removing the `id-token: read` permission (no OIDC usage), leaving only `contents: write` for publishing documentation to GitHub Pages.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e488ca46fb33f5b2b7d466113130eec82762e031. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->