### PR TITLE
feat: Deprecate the provider getState method

### DIFF
--- a/src/main/java/com/launchdarkly/openfeature/serverprovider/Provider.java
+++ b/src/main/java/com/launchdarkly/openfeature/serverprovider/Provider.java
@@ -129,6 +129,14 @@ public class Provider extends EventProvider {
         return evaluationDetailConverter.toEvaluationDetailsLdValue(detail);
     }
 
+    /**
+     * Get the state of this provider.
+     *
+     * @deprecated The OpenFeature SDK tracks provider state itself, based on initialization and the events this
+     * provider emits. Use {@link Client#getProviderState()} instead.
+     * @return the state of this provider
+     */
+    @Deprecated
     @Override
     public ProviderState getState() {
         synchronized (state) {


### PR DESCRIPTION
`FeatureProvider#getState()` is deprecated in the OpenFeature Java SDK, but this provider overrode it without marking it deprecated, so consumers got no signal to migrate.

- Marks the `getState()` override `@Deprecated` and documents `Client#getProviderState()` as the replacement
- Behavior is unchanged; the override is kept so existing callers keep getting real state rather than the SDK's `READY` default
- Removes the deprecation warning emitted when compiling this provider

@cursor review

<details>
<summary>Implementation details</summary>

**Context**

The OpenFeature SDK now tracks provider state itself, from `initialize` and from the events this provider emits (`ready`/`stale`/`error`/`configuration changed`), which is why `FeatureProvider#getState()` carries `@Deprecated` with "The state is handled by the SDK internally. Query the state from the Client instead."

**Alternatives considered**

Deleting the override entirely: rejected for now because `FeatureProvider` supplies a default that always returns `READY`, so any consumer still calling `provider.getState()` would silently get a wrong answer. Deprecating first gives a migration path; the override can be dropped in a future major.

**Testing**

`./gradlew test javadoc` — all 44 tests pass and javadoc builds with no new warnings.

No visual preview applies — this is a server-side provider change.

</details>


Link to Devin session: https://app.devin.ai/sessions/0c452d209ec54b068ba120b4c92b8f6c
Requested by: @kinyoklion

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Overview**
> Aligns this LaunchDarkly OpenFeature server provider with the OpenFeature Java SDK by marking the **`getState()`** override **`@Deprecated`** and documenting **`Client#getProviderState()`** as the replacement.
> 
> The override remains so callers still receive accurate provider state instead of the SDK default **`READY`**; behavior is unchanged aside from deprecation signaling and cleaner compilation (no missing-deprecation warning on this override).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 302cd661451907eeffa706d9e9e2d8e6221ad82f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->