### PR TITLE
feat: Populate OpenFeature flag metadata from the evaluation reason

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,6 +93,20 @@ API can be used to wait until the provider is ready, or it has encountered a per
 It the provider has been shutdown, because the OpenFeature API has been shutdown, or because the provider was no longer in use by the OpenFeature API, then the underlying LaunchDarkly SDK will be closed.
 This is an important consideration if you are using the `getLdClient` method of the provider to access the underlying SDK instance.
 
+### Flag Metadata
+
+Evaluation details include flag metadata containing the parts of the LaunchDarkly evaluation reason that do not fit
+into the OpenFeature reason and error code. Each entry is only present when it applies to the evaluation.
+
+| Key | Type | Description |
+|-----|------|-------------|
+| `variationIndex` | integer | The index of the variation that was returned. Absent when the SDK returned the default value. |
+| `inExperiment` | boolean | Only present, and always `true`, when the evaluation was part of an experiment. |
+| `ruleIndex` | integer | The index of the targeting rule that matched. Only present for a `RULE_MATCH` reason. |
+| `ruleId` | string | The identifier of the targeting rule that matched. Only present for a `RULE_MATCH` reason. |
+| `prerequisiteKey` | string | The key of the prerequisite flag that failed. Only present for a `PREREQUISITE_FAILED` reason. |
+| `bigSegmentsStatus` | string | The status of the Big Segments store, when the evaluation used Big Segments. |
+
 ### Examples
 
 #### A single user context

--- a/src/main/java/com/launchdarkly/openfeature/serverprovider/EvaluationDetailConverter.java
+++ b/src/main/java/com/launchdarkly/openfeature/serverprovider/EvaluationDetailConverter.java
@@ -14,6 +14,13 @@ import dev.openfeature.sdk.Value;
  * Converts an EvaluationDetail into an OpenFeature ResolutionDetails.
  */
 class EvaluationDetailConverter {
+    private static final String VARIATION_INDEX_KEY = "variationIndex";
+    private static final String IN_EXPERIMENT_KEY = "inExperiment";
+    private static final String RULE_INDEX_KEY = "ruleIndex";
+    private static final String RULE_ID_KEY = "ruleId";
+    private static final String PREREQUISITE_KEY_KEY = "prerequisiteKey";
+    private static final String BIG_SEGMENTS_STATUS_KEY = "bigSegmentsStatus";
+
     LDLogger logger;
     LDValueConverter ldValueConverter;
 
@@ -72,22 +79,22 @@ class EvaluationDetailConverter {
     private static ImmutableMetadata FlagMetadata(EvaluationReason reason, boolean isDefault, int variationIndex) {
         var builder = ImmutableMetadata.builder();
         if (!isDefault) {
-            builder.addInteger("variationIndex", variationIndex);
+            builder.addInteger(VARIATION_INDEX_KEY, variationIndex);
         }
         if (reason.isInExperiment()) {
-            builder.addBoolean("inExperiment", true);
+            builder.addBoolean(IN_EXPERIMENT_KEY, true);
         }
         if (reason.getKind() == EvaluationReason.Kind.RULE_MATCH) {
-            builder.addInteger("ruleIndex", reason.getRuleIndex());
+            builder.addInteger(RULE_INDEX_KEY, reason.getRuleIndex());
             if (reason.getRuleId() != null) {
-                builder.addString("ruleId", reason.getRuleId());
+                builder.addString(RULE_ID_KEY, reason.getRuleId());
             }
         }
         if (reason.getPrerequisiteKey() != null) {
-            builder.addString("prerequisiteKey", reason.getPrerequisiteKey());
+            builder.addString(PREREQUISITE_KEY_KEY, reason.getPrerequisiteKey());
         }
         if (reason.getBigSegmentsStatus() != null) {
-            builder.addString("bigSegmentsStatus", reason.getBigSegmentsStatus().name());
+            builder.addString(BIG_SEGMENTS_STATUS_KEY, reason.getBigSegmentsStatus().name());
         }
 
         return builder.build();

--- a/src/main/java/com/launchdarkly/openfeature/serverprovider/EvaluationDetailConverter.java
+++ b/src/main/java/com/launchdarkly/openfeature/serverprovider/EvaluationDetailConverter.java
@@ -5,6 +5,7 @@ import com.launchdarkly.sdk.EvaluationDetail;
 import com.launchdarkly.sdk.EvaluationReason;
 import com.launchdarkly.sdk.LDValue;
 import dev.openfeature.sdk.ErrorCode;
+import dev.openfeature.sdk.ImmutableMetadata;
 import dev.openfeature.sdk.ProviderEvaluation;
 import dev.openfeature.sdk.Reason;
 import dev.openfeature.sdk.Value;
@@ -62,6 +63,31 @@ class EvaluationDetailConverter {
         }
         if (!isDefault) {
             builder.variant(String.valueOf(variationIndex));
+        }
+        builder.flagMetadata(FlagMetadata(reason, isDefault, variationIndex));
+
+        return builder.build();
+    }
+
+    private static ImmutableMetadata FlagMetadata(EvaluationReason reason, boolean isDefault, int variationIndex) {
+        var builder = ImmutableMetadata.builder();
+        if (!isDefault) {
+            builder.addInteger("variationIndex", variationIndex);
+        }
+        if (reason.isInExperiment()) {
+            builder.addBoolean("inExperiment", true);
+        }
+        if (reason.getKind() == EvaluationReason.Kind.RULE_MATCH) {
+            builder.addInteger("ruleIndex", reason.getRuleIndex());
+            if (reason.getRuleId() != null) {
+                builder.addString("ruleId", reason.getRuleId());
+            }
+        }
+        if (reason.getPrerequisiteKey() != null) {
+            builder.addString("prerequisiteKey", reason.getPrerequisiteKey());
+        }
+        if (reason.getBigSegmentsStatus() != null) {
+            builder.addString("bigSegmentsStatus", reason.getBigSegmentsStatus().name());
         }
 
         return builder.build();

--- a/src/test/java/com/launchdarkly/openfeature/serverprovider/EvaluationDetailConverterTest.java
+++ b/src/test/java/com/launchdarkly/openfeature/serverprovider/EvaluationDetailConverterTest.java
@@ -155,4 +155,79 @@ public class EvaluationDetailConverterTest {
 
         assertEquals(17.0, nestedList.get(0).asDouble(), EPSILON);
     }
+
+    @Test
+    public void itIncludesTheVariationIndexInFlagMetadata() {
+        EvaluationDetail<Boolean> detail = EvaluationDetail.fromValue(
+                true, 3, EvaluationReason.fallthrough());
+
+        ImmutableMetadata metadata = evaluationDetailConverter.toEvaluationDetails(detail).getFlagMetadata();
+
+        assertEquals(3, metadata.getInteger("variationIndex"));
+        assertNull(metadata.getBoolean("inExperiment"));
+    }
+
+    @Test
+    public void itOmitsTheVariationIndexForDefaultValues() {
+        EvaluationDetail<Boolean> detail = EvaluationDetail.fromValue(
+                true, EvaluationDetail.NO_VARIATION,
+                EvaluationReason.error(EvaluationReason.ErrorKind.FLAG_NOT_FOUND));
+
+        ImmutableMetadata metadata = evaluationDetailConverter.toEvaluationDetails(detail).getFlagMetadata();
+
+        assertNull(metadata.getInteger("variationIndex"));
+    }
+
+    @Test
+    public void itIncludesExperimentationInformationInFlagMetadata() {
+        EvaluationDetail<Boolean> detail = EvaluationDetail.fromValue(
+                true, 1, EvaluationReason.fallthrough(true));
+
+        ImmutableMetadata metadata = evaluationDetailConverter.toEvaluationDetails(detail).getFlagMetadata();
+
+        assertEquals(true, metadata.getBoolean("inExperiment"));
+    }
+
+    @Test
+    public void itIncludesRuleInformationInFlagMetadata() {
+        EvaluationDetail<Boolean> detail = EvaluationDetail.fromValue(
+                true, 1, EvaluationReason.ruleMatch(4, "the-rule-id"));
+
+        ImmutableMetadata metadata = evaluationDetailConverter.toEvaluationDetails(detail).getFlagMetadata();
+
+        assertEquals(4, metadata.getInteger("ruleIndex"));
+        assertEquals("the-rule-id", metadata.getString("ruleId"));
+    }
+
+    @Test
+    public void itIncludesThePrerequisiteKeyInFlagMetadata() {
+        EvaluationDetail<Boolean> detail = EvaluationDetail.fromValue(
+                true, 0, EvaluationReason.prerequisiteFailed("the-prerequisite-key"));
+
+        ImmutableMetadata metadata = evaluationDetailConverter.toEvaluationDetails(detail).getFlagMetadata();
+
+        assertEquals("the-prerequisite-key", metadata.getString("prerequisiteKey"));
+    }
+
+    @Test
+    public void itIncludesTheBigSegmentsStatusInFlagMetadata() {
+        EvaluationDetail<Boolean> detail = EvaluationDetail.fromValue(
+                true, 0, EvaluationReason.fallthrough()
+                        .withBigSegmentsStatus(EvaluationReason.BigSegmentsStatus.STALE));
+
+        ImmutableMetadata metadata = evaluationDetailConverter.toEvaluationDetails(detail).getFlagMetadata();
+
+        assertEquals("STALE", metadata.getString("bigSegmentsStatus"));
+    }
+
+    @Test
+    public void itIncludesFlagMetadataForObjectResults() {
+        EvaluationDetail<LDValue> detail = EvaluationDetail.fromValue(
+                new ObjectBuilder().put("aKey", "aValue").build(), 2, EvaluationReason.fallthrough(true));
+
+        ImmutableMetadata metadata = evaluationDetailConverter.toEvaluationDetailsLdValue(detail).getFlagMetadata();
+
+        assertEquals(2, metadata.getInteger("variationIndex"));
+        assertEquals(true, metadata.getBoolean("inExperiment"));
+    }
 }


### PR DESCRIPTION
The provider discarded everything in the LaunchDarkly evaluation reason that did not fit into the OpenFeature reason string, so OpenFeature users could not tell that an evaluation was part of an experiment; the reason detail is now exposed as OpenFeature flag metadata.

- `ProviderEvaluation.flagMetadata` now carries `variationIndex`, `inExperiment`, `ruleIndex`, `ruleId`, `prerequisiteKey`, and `bigSegmentsStatus`
- Each entry is only present when it applies to the evaluation, so callers must null-check — `inExperiment` in particular is absent rather than `false` for non-experiment evaluations
- Key names match the LaunchDarkly reason field names and the attribute names used by the LaunchDarkly OpenTelemetry hooks
- Documented the keys in the README

@cursor review

<details>
<summary>Implementation details</summary>

**Requirements**

- [x] I have added test coverage for new or changed functionality
- [x] I have followed the repository's pull request submission guidelines
- [x] I have validated my changes against all supported platform versions

**Related issues**

None; this is one of several gaps found while auditing the LaunchDarkly OpenFeature providers against the OpenFeature specification.

**Describe the solution you've provided**

`EvaluationDetailConverter.getProviderEvaluation` builds an `ImmutableMetadata` from the `EvaluationReason`. Both entry points (typed values and `LDValue` results) go through it, so object and array evaluations get metadata too.

`variationIndex` duplicates the information in `variant`, but as an integer rather than a stringified index, which is what consumers reading metadata for telemetry want. It is omitted along with `variant` when the SDK returned the default value.

The OpenFeature telemetry conventions only reserve `contextId`, `flagSetId`, and `version`; none of the three map to a LaunchDarkly concept available on the evaluation detail (`contextId` would need the canonical context key rather than the reason, and could be added separately). Everything here is therefore LaunchDarkly-specific, named after the reason fields so it lines up with `EvaluationReason` and with the `feature_flag.result.*` attributes the LaunchDarkly OTel hook emits.

**Describe alternatives you've considered**

- A single nested `reason` structure: `ImmutableMetadata` only holds scalars, and flat keys are what telemetry hooks read.
- Always emitting `inExperiment: false`: cheap for consumers, but it makes the metadata claim knowledge about evaluations where the reason carries none.

**Additional context**

`./gradlew test javadoc` passes, including new cases per metadata entry and one covering object results. Nothing outside the converter changes. No visual preview applies — this is a server-side provider change.

</details>


Link to Devin session: https://app.devin.ai/sessions/0c452d209ec54b068ba120b4c92b8f6c
Requested by: @kinyoklion

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Overview**
> **OpenFeature evaluations now expose LaunchDarkly-specific details on `ProviderEvaluation.flagMetadata`**, so consumers can see experiment participation, rule matches, prerequisites, and Big Segments status without parsing the reason string alone.
> 
> `EvaluationDetailConverter` builds `ImmutableMetadata` from each `EvaluationReason` and attaches it on every conversion path (typed values and `LDValue` object/array results). Keys are included only when they apply: `variationIndex` (integer, omitted for default values), `inExperiment` (only when true), `ruleIndex`/`ruleId` for rule matches, `prerequisiteKey`, and `bigSegmentsStatus`. The README adds a **Flag Metadata** table describing these fields.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c93fd2c7aff8cec0d94c0b1cc874715be4fa9faa. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->