### PR TITLE
fix: Include the last data source error in the provider error event

### DIFF
--- a/src/main/java/com/launchdarkly/openfeature/serverprovider/Provider.java
+++ b/src/main/java/com/launchdarkly/openfeature/serverprovider/Provider.java
@@ -210,7 +210,10 @@ public class Provider extends EventProvider {
                 // Our client/provider cannot be restarted, so we just go to error.
                 setState(ProviderState.ERROR);
                 completer.complete(false);
-                emitProviderError(ProviderEventDetails.builder().message("Provider shutdown").build());
+                var message = res.getLastError() != null
+                    ? res.getLastError().getMessage()
+                    : "the provider has encountered a permanent error or has been shutdown";
+                emitProviderError(ProviderEventDetails.builder().message(message).build());
             }
         }
     }

--- a/src/test/java/com/launchdarkly/openfeature/serverprovider/LifeCycleTest.java
+++ b/src/test/java/com/launchdarkly/openfeature/serverprovider/LifeCycleTest.java
@@ -37,13 +37,19 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 class DelayedDataSource implements DataSource {
     private Duration startDelay;
     private boolean willError;
+    private boolean errorAfterInitialization;
     private boolean initialized = false;
     private Object lock = new Object();
     DataSourceUpdateSink sink;
 
     DelayedDataSource(Duration delay, boolean error, DataSourceUpdateSink sink) {
+        this(delay, error, false, sink);
+    }
+
+    DelayedDataSource(Duration delay, boolean error, boolean errorAfterInitialization, DataSourceUpdateSink sink) {
         startDelay = delay;
         willError = error;
+        this.errorAfterInitialization = errorAfterInitialization;
         this.sink = sink;
     }
 
@@ -57,6 +63,14 @@ class DelayedDataSource implements DataSource {
                     sink.updateStatus(DataSourceStatusProvider.State.VALID, null);
                     synchronized (lock) {
                         initialized = true;
+                    }
+                    if (errorAfterInitialization) {
+                        sink.updateStatus(DataSourceStatusProvider.State.OFF,
+                            new DataSourceStatusProvider.ErrorInfo(
+                                DataSourceStatusProvider.ErrorKind.NETWORK_ERROR,
+                                404,
+                                "bad",
+                                LocalDateTime.now().toInstant(ZoneOffset.UTC)));
                     }
                 } else {
                     sink.updateStatus(DataSourceStatusProvider.State.OFF,
@@ -86,15 +100,25 @@ class DelayedDataSource implements DataSource {
 class DelayedDataSourceFactory implements ComponentConfigurer<DataSource> {
     private Duration startDelay;
     private boolean willError;
+    private boolean errorAfterInitialization;
 
     DelayedDataSourceFactory(Duration delay, boolean error) {
+        this(delay, error, false);
+    }
+
+    DelayedDataSourceFactory(Duration delay, boolean error, boolean errorAfterInitialization) {
         startDelay = delay;
         willError = error;
+        this.errorAfterInitialization = errorAfterInitialization;
     }
 
     @Override
     public DataSource build(ClientContext clientContext) {
-        return new DelayedDataSource(startDelay, willError, clientContext.getDataSourceUpdateSink());
+        return new DelayedDataSource(
+            startDelay,
+            willError,
+            errorAfterInitialization,
+            clientContext.getDataSourceUpdateSink());
     }
 }
 
@@ -220,5 +244,24 @@ public class LifeCycleTest {
         assertEquals(ProviderState.ERROR, provider.getState());
 
         assertTrue(gotErrorEvent.get(1000, TimeUnit.MILLISECONDS));
+    }
+
+    @Test
+    public void itIncludesTheDataSourceErrorInErrorEvents() throws Exception {
+        var config = new LDConfig.Builder()
+            .startWait(Duration.ZERO)
+            .dataSource(new DelayedDataSourceFactory(Duration.ofMillis(100), false, true))
+            .events(Components.noEvents())
+            .build();
+        var provider = new Provider("fake-key", config);
+        CompletableFuture<String> errorMessage = new CompletableFuture<>();
+
+        OpenFeatureAPI.getInstance().on(ProviderEvent.PROVIDER_ERROR, (detail) -> {
+            errorMessage.complete(detail.getMessage());
+        });
+
+        OpenFeatureAPI.getInstance().setProviderAndWait(provider);
+
+        assertEquals("bad", errorMessage.get(1000, TimeUnit.MILLISECONDS));
     }
 }


### PR DESCRIPTION
The `PROVIDER_ERROR` event now carries the last data source error instead of a fixed "Provider shutdown" message.

- Matches the OFP spec, which requires the error event to report the last data source error, with a description as a fallback
- Matches the `PROVIDER_STALE` branch, which already reports the last error, and the wording used by the Python provider

<details>
<summary>Implementation details</summary>

Found during the weekly OpenFeature provider audit against `launchdarkly/sdk-specs` (`OFP`).

`handleDataSourceStatus` discarded `res.getLastError()` in the `OFF` case, so an application listening for `PROVIDER_ERROR` had no way to see why the data source permanently failed (for example a `401` from an invalid SDK key). The state transition and initialization behavior are unchanged.

**Requirements**

- [x] I have added test coverage for new or changed functionality
- [x] I have followed the repository's [pull request submission guidelines](../blob/main/CONTRIBUTING.md#submitting-pull-requests)
- [x] I have validated my changes against all supported platform versions

**Related issues**

None.

**Describe alternatives you've considered**

Keeping the static message and adding the error as event metadata: OpenFeature only exposes a message on the event details, so the message is the right place for it.

**Testing**

`./gradlew test --tests com.launchdarkly.openfeature.serverprovider.LifeCycleTest checkstyleMain`

</details>

Link to Devin session: https://app.devin.ai/sessions/38a6eaf69fcf41109e136a1d0fe5e899
Requested by: @kinyoklion