### PR TITLE
docs: Add an OpenFeature feature matrix to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,28 @@ This provider is designed primarily for use in multi-user systems such as web se
 
 This version of the LaunchDarkly provider works with Java 11 and above.
 
+## Feature matrix
+
+This matrix mirrors the [feature matrix of the OpenFeature SDK for Java](https://github.com/open-feature/java-sdk#-features) and describes what this provider supports. Rows which are not supported state whether the limitation comes from the OpenFeature Java SDK or from the provider.
+
+| Status | Feature                         | Notes                                                                                                                                                                                                                     |
+|--------|---------------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| ✅      | Providers                       | Evaluates boolean, string, integer, double, and object flags through the LaunchDarkly Java SDK.                                                                                                                            |
+| ✅      | Targeting                       | The `EvaluationContext` is converted to a LaunchDarkly single or multi-context. See [OpenFeature Specific Considerations](#openfeature-specific-considerations).                                                           |
+| ✅      | Multi-provider (experimental)   | Provided by the OpenFeature SDK, which delegates to each provider in turn; no provider support is required.                                                                                                                |
+| ✅      | Hooks                           | Hooks are registered on the OpenFeature API and client; the provider requires no additional support and its results are visible to hooks, including [flag metadata](#flag-metadata).                                       |
+| ✅      | Tracking                        | `track` sends a LaunchDarkly custom event for the evaluation context, with the tracking event value and remaining details attached.                                                                                        |
+| ✅      | Logging                         | The provider logs through the logging configuration of the `LDConfig` it is given.                                                                                                                                         |
+| ✅      | Domains                         | Domains bind clients to providers in the OpenFeature SDK; a separate provider instance may be registered per domain.                                                                                                       |
+| ✅      | Eventing                        | LaunchDarkly data source status changes are emitted as `PROVIDER_READY`, `PROVIDER_STALE`, and `PROVIDER_ERROR`. Flag changes are emitted as `PROVIDER_CONFIGURATION_CHANGED` with the changed flag key.                    |
+| ⚠️      | Initialization                  | `initialize` reports whether the LaunchDarkly client became ready, and a failure results in the `ERROR` state so that cached or fallback flag data is still evaluated. It has no timeout of its own and waits until the data source becomes valid or permanently fails: [#58](https://github.com/launchdarkly/openfeature-java-server/issues/58). |
+| ✅      | Shutdown                        | `shutdown` closes the LaunchDarkly client. A closed client cannot be restarted, so a new provider instance is required afterward.                                                                                          |
+| ✅      | Transaction Context Propagation | Provided by the OpenFeature SDK, which merges the transaction context into the evaluation context before the provider is called; no provider support is required.                                                          |
+| ✅      | Extending                       | This provider is itself an extension of the OpenFeature SDK. The underlying LaunchDarkly client is available through `getLdClient()` for functionality with no OpenFeature equivalent.                                      |
+| ✅      | Flag metadata                   | LaunchDarkly evaluation reason details are returned as OpenFeature flag metadata. See [Flag Metadata](#flag-metadata).                                                                                                     |
+
+<sub>Supported: ✅ | Partially supported: ⚠️ | Not supported: ❌</sub>
+
 ## Getting started
 
 ### Requisites


### PR DESCRIPTION
Adds a feature matrix to the README mirroring the OpenFeature Java SDK's own feature table, so a reader can see at a glance what this provider supports.

- Same rows and order as the [OpenFeature Java SDK matrix](https://github.com/open-feature/java-sdk#-features), plus `Initialization` and `Flag metadata`
- Rows that are not fully supported state whether the limitation is in the OpenFeature SDK or in the provider, and link the tracking issue
- Only `Initialization` is marked partial: it has no timeout of its own ([#58](https://github.com/launchdarkly/openfeature-java-server/issues/58))
- The same matrix format is being added to the Python, .NET and JavaScript providers, and already exists in the Ruby provider, so they can be compared side by side

<details>
<summary>Implementation details</summary>

Written during the weekly OpenFeature provider audit. Each row was checked against the provider source rather than assumed; the wording follows the matrix already present in the Ruby provider README.

**Requirements**

- [x] I have added test coverage for new or changed functionality (documentation only)
- [x] I have followed the repository's [pull request submission guidelines](../blob/main/CONTRIBUTING.md#submitting-pull-requests)
- [x] I have validated my changes against all supported platform versions

**Related issues**

[#58](https://github.com/launchdarkly/openfeature-java-server/issues/58)

</details>

Link to Devin session: https://app.devin.ai/sessions/38a6eaf69fcf41109e136a1d0fe5e899
Requested by: @kinyoklion